### PR TITLE
Update to localize show/hide labels

### DIFF
--- a/show-hide-comments.js
+++ b/show-hide-comments.js
@@ -11,11 +11,11 @@ jQuery(document).ready(function() {
 	jQuery(commentsDiv).hide();
 
 	// Append a link to show/hide
-	jQuery('<a/>')
-		.attr('class', 'toggle-comments h3')
-		.attr('href', '#')
-		.html('show &gt;&gt; ')
-		.insertBefore(commentsDiv);
+        jQuery('<a/>')
+                .attr('class', 'toggle-comments h3')
+                .attr('href', '#')
+                .html(arcShowHideData.show_label)
+                .insertBefore(commentsDiv);
 
 	// Encase button in #toggle-comments-container span
 	jQuery('.toggle-comments').wrap(jQuery('<div/>', {
@@ -29,9 +29,9 @@ jQuery(document).ready(function() {
 	// Show/hide the div using jQuery's toggle()
 	jQuery(commentsDiv).toggle('slow', function() {
 	// change the text of the anchor
-		var anchor = jQuery('.toggle-comments');
-		var anchorText = anchor.html() == 'show &gt;&gt; ' ? 'hide &lt;&lt; ' : 'show &gt;&gt; ';
-		jQuery(anchor).html(anchorText);
+                var anchor = jQuery('.toggle-comments');
+                var anchorText = anchor.html() == arcShowHideData.show_label ? arcShowHideData.hide_label : arcShowHideData.show_label;
+                jQuery(anchor).html(anchorText);
 	});
 	});
  

--- a/show-hide-comments.php
+++ b/show-hide-comments.php
@@ -6,8 +6,12 @@
 */
 
 function load_show_hide_comments_js() { // load the file
-	wp_register_script( 'show_hide_comments', plugins_url( '/show-hide-comments.js', __FILE__ ), array('jquery'), '', true ); // register the file
-	wp_enqueue_script( 'show_hide_comments' ); // enqueue the file
+        wp_register_script( 'show_hide_comments', plugins_url( '/show-hide-comments.js', __FILE__ ), array('jquery'), '', true ); // register the file
+        wp_enqueue_script( 'show_hide_comments' ); // enqueue the file
+        wp_localize_script( 'show_hide_comments', 'arcShowHideData', array(
+                'show_label' => __( 'show &gt;&gt; ', 'arc-custom-show-hide-comments' ),
+                'hide_label' => __( 'hide &lt;&lt; ', 'arc-custom-show-hide-comments' ),
+        ) );
 }
 
 add_action('wp_enqueue_scripts', 'load_show_hide_comments_js'); // initiate the function


### PR DESCRIPTION
## Summary
- pass translatable labels from PHP using `wp_localize_script`
- use those labels in `show-hide-comments.js`

## Testing
- `php -l show-hide-comments.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684263c3b7288321b7038e4a76531642